### PR TITLE
Change list labels colour from on_blue to blue

### DIFF
--- a/hubugs/templates/default/view/list.txt
+++ b/hubugs/templates/default/view/list.txt
@@ -11,7 +11,7 @@
 {%- block body %}
 {%- for bug in bugs %}
 {%- if bug.labels %}
-{%- set formatted_labels = " [" + bug.labels | join(", ") | colourise("on_blue") + "]" %}
+{%- set formatted_labels = " [" + bug.labels | join(", ") | colourise("blue") + "]" %}
 {% else %}
 {%- set formatted_labels = "" %}
 {% endif -%}


### PR DESCRIPTION
The list labels are not readable with the popular [Solarized](http://ethanschoonover.com/solarized) colour scheme.
### Before:

![](http://i.imgur.com/qbhG7.png)
### After:

![Fixed](http://i.imgur.com/Qixtx.png)
